### PR TITLE
Change order predicate

### DIFF
--- a/statik.go
+++ b/statik.go
@@ -106,7 +106,11 @@ func generate(dir string) bool {
 	}
 	if sortEntries {
 		sort.Slice(entries, func(i, j int) bool {
-			return entries[i].IsDir() && !entries[j].IsDir()
+			isFirstEntryDir := entries[i].IsDir()
+			isSecondEntryDir := entries[j].IsDir()
+			return isFirstEntryDir && !isSecondEntryDir ||
+				(isFirstEntryDir || !isSecondEntryDir) &&
+					entries[i].Name() < entries[j].Name()
 		})
 	}
 


### PR DESCRIPTION
When two entries are both directories or both files, they are sorted based on 
their names. `gofmt` with default rules was used as code formatter.