### PR TITLE
fix(css): set smaller h1 font-size for mobile view

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,6 +3,8 @@
   --b: #fbf1c7;
   --f: #282828;
   --d: #af3a03;
+  font-family: monospace;
+  font-size: 16px;
 }
 
 * {
@@ -11,11 +13,13 @@
 }
 
 body {
-  font-size: 16px;
-  font-family: monospace;
   margin: 0;
   padding: 1.5rem;
   line-height: 1.8;
+}
+
+h1 {
+  font-size: 1.5rem;
 }
 
 a {
@@ -49,12 +53,6 @@ a {
     --f: #fbf1c7;
     --d: #fe8019;
   }
-}
-
-@media(max-width:600px) {
-    h1 {
-        font-size: 1.5em;
-    }
 }
 
 @media (max-width: 880px) {

--- a/style.css
+++ b/style.css
@@ -51,6 +51,12 @@ a {
   }
 }
 
+@media(max-width:600px) {
+    h1 {
+        font-size: 1.5em;
+    }
+}
+
 @media (max-width: 880px) {
   .g {
     grid-template-columns: 7fr 3fr;


### PR DESCRIPTION
I noticed that that the h1 size was to big from the mobile view, so i made it smaller, here is the difference:
Before: 
![image](https://user-images.githubusercontent.com/63465494/170842080-6b22357b-7733-4cd3-bab7-cfcd1e4fdeb6.png)
Now: 
![image](https://user-images.githubusercontent.com/63465494/170842088-0cfdd439-f197-4415-ba07-c1d397778da8.png)

NOTE: i used this https://mui.com/material-ui/customization/breakpoints/ (sm breakpoint) in order to chose the breakpoint size. I don't think it matters if i put the h1 rule in the 880 breakpoint, just matter of taste.